### PR TITLE
Fixing notify messages.

### DIFF
--- a/webui/app/static/css/styles.css
+++ b/webui/app/static/css/styles.css
@@ -25,3 +25,7 @@
     padding: 0.6rem 1rem;
   }
 }
+
+.notifyjs-bootstrap-wrap-spaces {
+  white-space: normal !important;
+}

--- a/webui/app/static/css/styles.css
+++ b/webui/app/static/css/styles.css
@@ -28,4 +28,17 @@
 
 .notifyjs-bootstrap-wrap-spaces {
   white-space: normal !important;
+  word-break: break-word;
+}
+
+div.form-group.w100prc {
+  position: relative;
+}
+
+div.form-group.w100prc div.notifyjs-wrapper.notifyjs-hidable {
+  width: 100%;
+}
+
+div.form-group.w100prc div.notifyjs-container {
+  margin-bottom: 1rem;
 }

--- a/webui/app/static/js/index.js
+++ b/webui/app/static/js/index.js
@@ -88,10 +88,16 @@ $(document).ready(function () {
     // contains a server message, and if contains, show it to user
     var $message = $("#message");
     var text = $message.text().trim();
+
+    var notify_classes;
+    if ($message.data("category") == null) notify_classes = ['error', 'wrap-spaces'];
+    else notify_classes = [$message.data("category"), 'wrap-spaces'];
+
     if (text !== '') {
         $.notify(text, {
+            clickToHide: true,
             position: "top right",
-            className: $message.data("category"),
+            className: notify_classes,
             autoHide: false
         })
     }

--- a/webui/app/static/js/index.js
+++ b/webui/app/static/js/index.js
@@ -94,9 +94,10 @@ $(document).ready(function () {
     else notify_classes = [$message.data("category"), 'wrap-spaces'];
 
     if (text !== '') {
-        $.notify(text, {
+        $("#btnSubmit").notify(text, {
             clickToHide: true,
-            position: "top right",
+            arrowShow: false,
+            position: "bottom left",
             className: notify_classes,
             autoHide: false
         })


### PR DESCRIPTION
Fixed a problem with notify messages. The issue was with a default CSS rule, `white-spaces: nowrap;` I've added an extra class for this specific message with `white-space: normal !important;` rule to overwrite the defaults.

Also, I've added "hiding message on click" behaviour, previously it was impossible to close notification, and using "autohide in x seconds" isn't a good idea for errors messages either, so closing on click is quite an option.